### PR TITLE
Add random filenames feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+images/
 *.bak
 .gitattributes
 .last_checked

--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -337,7 +337,7 @@
       "text/plain": [
        "['https://cdn3.volusion.com/9nxdj.fchy5/v/vspfiles/photos/WR-13710-2T.jpg?1528880561',\n",
        " 'http://4.bp.blogspot.com/-GKGVUan6I3w/UOQtWCzichI/AAAAAAAANs0/mxox-FdrnRA/s1600/019.jpg',\n",
-       " 'https://i.pinimg.com/736x/fa/fd/83/fafd8381375e3724bb2b2842ad175792--alessandra-ambrosio-dip-dyed.jpg']"
+       " 'https://i.ebayimg.com/images/g/ZNYAAOSwfHBceXDy/s-l300.jpg']"
       ]
      },
      "execution_count": null,
@@ -418,7 +418,9 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def download_urls(path: Union[str, Path], links: list) -> list:\n",
+    "import uuid\n",
+    "\n",
+    "def download_urls(path: Union[str, Path], links: list, random_names=False) -> list:\n",
     "  '''Downloads urls to the given path. Returns a list of Path objects for files downloaded to disc.'''\n",
     "  if(len(links) == 0):\n",
     "    print(\"Nothing to download!\"); return\n",
@@ -431,7 +433,9 @@
     "  pbar.comment = 'Images downloaded'\n",
     "\n",
     "  i = 1\n",
-    "  mk_fp = lambda x: path/(str(x).zfill(3) + \".jpg\")\n",
+    "  mk_uniq = lambda : '_' + str(uuid.uuid4())[:8] if random_names else ''\n",
+    "  mk_fp = lambda x: path/(str(x).zfill(3) + mk_uniq() + \".jpg\")\n",
+    "  \n",
     "  is_file = lambda x: mk_fp(x).exists()\n",
     "  while is_file(i): i += 1 # don't overwrite previous searches\n",
     "  \n",
@@ -466,7 +470,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Files will be saved as 001.jpg, 002.jpg etc but images already present will not be overwritten, so you can run multiple searches for the same label (eg: different genres of orchid all under one 'orchid' label) and file numbering will carry on from the last one on disc.\n",
+    "Files will be saved as 001.jpg, 002.jpg etc but images already present will not be overwritten, so you can run multiple searches for the same label (eg: different genres of orchid all under one 'orchid' label) and file numbering will carry on from the last one on disc. If the `random_names` parameter is set to `True`, a random string is tacked on to the name of the file like `001_4cda4d95.jpg`,`002__cc13976d.jpg` to ensure that the filenames are unique, even across directories.\n",
     "\n",
     "Downloaded files will be checked for validity so you should never end up with corrupt images or truncated downloads. (Let me know if anything duff gets through)\n",
     "\n",
@@ -482,7 +486,66 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading results into C:\\Users\\Joe\\Documents\\GitHub\\jmd_imagescraper\\images\\purple\n"
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "        <style>\n",
+       "            /* Turns off some styling */\n",
+       "            progress {\n",
+       "                /* gets rid of default border in Firefox and Opera. */\n",
+       "                border: none;\n",
+       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "                background-size: auto;\n",
+       "            }\n",
+       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "                background: #F44336;\n",
+       "            }\n",
+       "        </style>\n",
+       "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.00% [3/3 00:01<00:00 Images downloaded]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/001.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/002.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/003.jpg')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root = Path.cwd()/\"images\"\n",
+    "download_urls(root/\"purple\", links)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2\n"
      ]
     },
     {
@@ -517,9 +580,9 @@
     {
      "data": {
       "text/plain": [
-       "[Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/001.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/002.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/003.jpg')]"
+       "[Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/001_5eeb927e.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/002_e09a7de6.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/003_3c94f776.jpg')]"
       ]
      },
      "execution_count": null,
@@ -529,7 +592,7 @@
    ],
    "source": [
     "root = Path.cwd()/\"images\"\n",
-    "download_urls(root/\"purple\", links)"
+    "download_urls(root/\"purple2\", links, random_names=True)"
    ]
   },
   {
@@ -543,12 +606,13 @@
     "                           img_size: ImgSize=ImgSize.Cached, \n",
     "                           img_type: ImgType=ImgType.Photo,\n",
     "                           img_layout: ImgLayout=ImgLayout.Square,\n",
-    "                           img_color: ImgColor=ImgColor.All) -> list:\n",
+    "                           img_color: ImgColor=ImgColor.All, \n",
+    "                           random_names: bool=False) -> list:\n",
     "  '''Run a DuckDuckGo search and download the images. Returns a list of Path objects for files downloaded to disc.'''\n",
     "  \n",
     "  print(\"Duckduckgo search:\", keywords)\n",
     "  links = duckduckgo_scrape_urls(keywords, max_results, img_size, img_type, img_layout, img_color)\n",
-    "  return download_urls(Path(path)/label, links)"
+    "  return download_urls(Path(path)/label, links, random_names=random_names)"
    ]
   },
   {
@@ -568,7 +632,7 @@
      "output_type": "stream",
      "text": [
       "Duckduckgo search: nice clowns\n",
-      "Downloading results into C:\\Users\\Joe\\Documents\\GitHub\\jmd_imagescraper\\images\\Nice\n"
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice\n"
      ]
     },
     {
@@ -589,7 +653,7 @@
        "            }\n",
        "        </style>\n",
        "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [3/3 00:00<00:00 Images downloaded]\n",
+       "      100.00% [3/3 00:03<00:00 Images downloaded]\n",
        "    </div>\n",
        "    "
       ],
@@ -603,9 +667,9 @@
     {
      "data": {
       "text/plain": [
-       "[Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/001.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/002.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/003.jpg')]"
+       "[Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003.jpg')]"
       ]
      },
      "execution_count": null,
@@ -615,6 +679,65 @@
    ],
    "source": [
     "duckduckgo_search(root, \"Nice\", \"nice clowns\", max_results=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Duckduckgo search: nice clowns\n",
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "        <style>\n",
+       "            /* Turns off some styling */\n",
+       "            progress {\n",
+       "                /* gets rid of default border in Firefox and Opera. */\n",
+       "                border: none;\n",
+       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "                background-size: auto;\n",
+       "            }\n",
+       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "                background: #F44336;\n",
+       "            }\n",
+       "        </style>\n",
+       "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.00% [3/3 00:02<00:00 Images downloaded]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001_2da8aaba.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002_81b6e5b4.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003_956691f0.jpg')]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "duckduckgo_search(root, \"Nice\", \"nice clowns\", max_results=3, random_names=True)"
    ]
   },
   {
@@ -634,7 +757,7 @@
      "output_type": "stream",
      "text": [
       "Duckduckgo search: nice clowns\n",
-      "Downloading results into C:\\Users\\Joe\\Documents\\GitHub\\jmd_imagescraper\\images\\Nice\n"
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice\n"
      ]
     },
     {
@@ -655,7 +778,7 @@
        "            }\n",
        "        </style>\n",
        "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [3/3 00:00<00:00 Images downloaded]\n",
+       "      100.00% [3/3 00:02<00:00 Images downloaded]\n",
        "    </div>\n",
        "    "
       ],
@@ -671,7 +794,7 @@
      "output_type": "stream",
      "text": [
       "Duckduckgo search: scary clowns\n",
-      "Downloading results into C:\\Users\\Joe\\Documents\\GitHub\\jmd_imagescraper\\images\\Scary\n"
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary\n"
      ]
     },
     {
@@ -692,7 +815,7 @@
        "            }\n",
        "        </style>\n",
        "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [3/3 00:00<00:00 Images downloaded]\n",
+       "      100.00% [3/3 00:02<00:00 Images downloaded]\n",
        "    </div>\n",
        "    "
       ],
@@ -708,7 +831,7 @@
      "output_type": "stream",
      "text": [
       "Duckduckgo search: mimes\n",
-      "Downloading results into C:\\Users\\Joe\\Documents\\GitHub\\jmd_imagescraper\\images\\Mime\n"
+      "Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime\n"
      ]
     },
     {
@@ -729,7 +852,7 @@
        "            }\n",
        "        </style>\n",
        "      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [3/3 00:00<00:00 Images downloaded]\n",
+       "      100.00% [3/3 00:02<00:00 Images downloaded]\n",
        "    </div>\n",
        "    "
       ],
@@ -743,15 +866,15 @@
     {
      "data": {
       "text/plain": [
-       "[Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/004.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/005.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/006.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/001.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/002.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/003.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/001.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/002.jpg'),\n",
-       " Path('C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/003.jpg')]"
+       "[Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001_c040ccb0.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002_a7f8e765.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003_f05a000c.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/001_3a155a2d.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/002_55128fe1.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/003_12a21c43.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/001_9640f045.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/002_8c3198aa.jpg'),\n",
+       " Path('/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/003_5944b53a.jpg')]"
       ]
      },
      "execution_count": null,
@@ -765,7 +888,8 @@
     "    \"img_size\":    ImgSize.Cached, \n",
     "    \"img_type\":    ImgType.Photo,\n",
     "    \"img_layout\":  ImgLayout.Square,\n",
-    "    \"img_color\":   ImgColor.All\n",
+    "    \"img_color\":   ImgColor.All,\n",
+    "    \"random_names\": True\n",
     "}\n",
     "\n",
     "imgs = []\n",
@@ -875,7 +999,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>https://tse1.mm.bing.net/th?id=OIP.9lCTTlLeQV9...</td>\n",
+       "      <td>https://tse4.mm.bing.net/th?id=OIP.4h5GbgzyJgG...</td>\n",
        "      <td>Nice</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -913,7 +1037,7 @@
        "1  https://tse4.mm.bing.net/th?id=OIP.s3Ie8ax_Fa6...   Nice\n",
        "2  https://tse1.mm.bing.net/th?id=OIP.lwC5ho3Ta-T...   Nice\n",
        "3  https://tse4.mm.bing.net/th?id=OIP.glEf94S1eD0...   Nice\n",
-       "4  https://tse1.mm.bing.net/th?id=OIP.9lCTTlLeQV9...   Nice\n",
+       "4  https://tse4.mm.bing.net/th?id=OIP.4h5GbgzyJgG...   Nice\n",
        "5  https://tse3.mm.bing.net/th?id=OIP.zMsnePdSfSb...  Scary\n",
        "6  https://tse3.mm.bing.net/th?id=OIP.yhDrJ18seBC...  Scary\n",
        "7  https://tse1.mm.bing.net/th?id=OIP.y5tm55MMKcW...  Scary\n",
@@ -938,7 +1062,7 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def download_images_from_csv(path: Union[str, Path], csv: Union[str, Path], url_col: str=\"URL\", label_col: str=\"Label\"):\n",
+    "def download_images_from_csv(path: Union[str, Path], csv: Union[str, Path], url_col: str=\"URL\", label_col: str=\"Label\", random_names=False):\n",
     "    '''Download the URLs from a CSV file to the given path. Returns a list of Path objects for files downloaded to disc.'''\n",
     "    path = Path(path); csv = Path(csv);\n",
     "    \n",
@@ -949,7 +1073,7 @@
     "    for label in labels:\n",
     "        df_label = df.loc[df[label_col] == label]\n",
     "        urls = df_label[url_col].to_list()\n",
-    "        imgs.extend(download_urls(path/label, urls))\n",
+    "        imgs.extend(download_urls(path/label, urls, random_names=random_names))\n",
     "    \n",
     "    return imgs"
    ]

--- a/docs/core.html
+++ b/docs/core.html
@@ -353,7 +353,7 @@ nb_path: "00_core.ipynb"
 <div class="output_text output_subarea output_execute_result">
 <pre>[&#39;https://cdn3.volusion.com/9nxdj.fchy5/v/vspfiles/photos/WR-13710-2T.jpg?1528880561&#39;,
  &#39;http://4.bp.blogspot.com/-GKGVUan6I3w/UOQtWCzichI/AAAAAAAANs0/mxox-FdrnRA/s1600/019.jpg&#39;,
- &#39;https://i.pinimg.com/736x/fa/fd/83/fafd8381375e3724bb2b2842ad175792--alessandra-ambrosio-dip-dyed.jpg&#39;]</pre>
+ &#39;https://i.ebayimg.com/images/g/ZNYAAOSwfHBceXDy/s-l300.jpg&#39;]</pre>
 </div>
 
 </div>
@@ -460,7 +460,7 @@ nb_path: "00_core.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="download_urls" class="doc_header"><code>download_urls</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L155" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>download_urls</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>links</code></strong>:<code>list</code>)</p>
+<h4 id="download_urls" class="doc_header"><code>download_urls</code><a href="__main__.py#L4" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>download_urls</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>links</code></strong>:<code>list</code>, <strong><code>random_names</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Downloads urls to the given path. Returns a list of Path objects for files downloaded to disc.</p>
 
@@ -476,7 +476,7 @@ nb_path: "00_core.ipynb"
 
 <div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Files will be saved as 001.jpg, 002.jpg etc but images already present will not be overwritten, so you can run multiple searches for the same label (eg: different genres of orchid all under one 'orchid' label) and file numbering will carry on from the last one on disc.</p>
+<p>Files will be saved as 001.jpg, 002.jpg etc but images already present will not be overwritten, so you can run multiple searches for the same label (eg: different genres of orchid all under one 'orchid' label) and file numbering will carry on from the last one on disc. If the <code>random_names</code> parameter is set to <code>True</code>, a random string is tacked on to the name of the file like <code>001_4cda4d95.jpg</code>,<code>002__cc13976d.jpg</code> to ensure that the filenames are unique, even across directories.</p>
 <p>Downloaded files will be checked for validity so you should never end up with corrupt images or truncated downloads. (Let me know if anything duff gets through)</p>
 <p>Returns a list of Path objects for succesfully downloaded images.</p>
 
@@ -504,7 +504,77 @@ nb_path: "00_core.ipynb"
 <div class="output_area">
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\purple
+<pre>Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple
+</pre>
+</div>
+</div>
+
+<div class="output_area">
+
+
+<div class="output_html rendered_html output_subarea ">
+
+    <div>
+        <style>
+            /* Turns off some styling */
+            progress {
+                /* gets rid of default border in Firefox and Opera. */
+                border: none;
+                /* Needs to be in here for Safari polyfill so background images work as expected. */
+                background-size: auto;
+            }
+            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {
+                background: #F44336;
+            }
+        </style>
+      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
+      100.00% [3/3 00:01<00:00 Images downloaded]
+    </div>
+    
+</div>
+
+</div>
+
+<div class="output_area">
+
+
+
+<div class="output_text output_subarea output_execute_result">
+<pre>[Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/001.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/002.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple/003.jpg&#39;)]</pre>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+    {% endraw %}
+
+    {% raw %}
+    
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">root</span> <span class="o">=</span> <span class="n">Path</span><span class="o">.</span><span class="n">cwd</span><span class="p">()</span><span class="o">/</span><span class="s2">&quot;images&quot;</span>
+<span class="n">download_urls</span><span class="p">(</span><span class="n">root</span><span class="o">/</span><span class="s2">&quot;purple2&quot;</span><span class="p">,</span> <span class="n">links</span><span class="p">,</span> <span class="n">random_names</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2
 </pre>
 </div>
 </div>
@@ -540,9 +610,9 @@ nb_path: "00_core.ipynb"
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>[Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/001.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/002.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/purple/003.jpg&#39;)]</pre>
+<pre>[Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/001_5eeb927e.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/002_e09a7de6.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/purple2/003_3c94f776.jpg&#39;)]</pre>
 </div>
 
 </div>
@@ -571,7 +641,7 @@ nb_path: "00_core.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="duckduckgo_search" class="doc_header"><code>duckduckgo_search</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L199" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>duckduckgo_search</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>label</code></strong>:<code>str</code>, <strong><code>keywords</code></strong>:<code>str</code>, <strong><code>max_results</code></strong>:<code>int</code>=<em><code>100</code></em>, <strong><code>img_size</code></strong>:<a href="/jmd_imagescraper/core.html#ImgSize"><code>ImgSize</code></a>=<em><code>&lt;ImgSize.Cached: ''&gt;</code></em>, <strong><code>img_type</code></strong>:<a href="/jmd_imagescraper/core.html#ImgType"><code>ImgType</code></a>=<em><code>&lt;ImgType.Photo: 'photo'&gt;</code></em>, <strong><code>img_layout</code></strong>:<a href="/jmd_imagescraper/core.html#ImgLayout"><code>ImgLayout</code></a>=<em><code>&lt;ImgLayout.Square: 'Square'&gt;</code></em>, <strong><code>img_color</code></strong>:<a href="/jmd_imagescraper/core.html#ImgColor"><code>ImgColor</code></a>=<em><code>&lt;ImgColor.All: ''&gt;</code></em>)</p>
+<h4 id="duckduckgo_search" class="doc_header"><code>duckduckgo_search</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L203" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>duckduckgo_search</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>label</code></strong>:<code>str</code>, <strong><code>keywords</code></strong>:<code>str</code>, <strong><code>max_results</code></strong>:<code>int</code>=<em><code>100</code></em>, <strong><code>img_size</code></strong>:<a href="/jmd_imagescraper/core.html#ImgSize"><code>ImgSize</code></a>=<em><code>&lt;ImgSize.Cached: ''&gt;</code></em>, <strong><code>img_type</code></strong>:<a href="/jmd_imagescraper/core.html#ImgType"><code>ImgType</code></a>=<em><code>&lt;ImgType.Photo: 'photo'&gt;</code></em>, <strong><code>img_layout</code></strong>:<a href="/jmd_imagescraper/core.html#ImgLayout"><code>ImgLayout</code></a>=<em><code>&lt;ImgLayout.Square: 'Square'&gt;</code></em>, <strong><code>img_color</code></strong>:<a href="/jmd_imagescraper/core.html#ImgColor"><code>ImgColor</code></a>=<em><code>&lt;ImgColor.All: ''&gt;</code></em>, <strong><code>random_names</code></strong>:<code>bool</code>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Run a DuckDuckGo search and download the images. Returns a list of Path objects for files downloaded to disc.</p>
 
@@ -613,7 +683,7 @@ nb_path: "00_core.ipynb"
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Duckduckgo search: nice clowns
-Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\Nice
+Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice
 </pre>
 </div>
 </div>
@@ -637,7 +707,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
             }
         </style>
       <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
-      100.00% [3/3 00:00<00:00 Images downloaded]
+      100.00% [3/3 00:03<00:00 Images downloaded]
     </div>
     
 </div>
@@ -649,9 +719,79 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>[Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/001.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/002.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/003.jpg&#39;)]</pre>
+<pre>[Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003.jpg&#39;)]</pre>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+    {% endraw %}
+
+    {% raw %}
+    
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">duckduckgo_search</span><span class="p">(</span><span class="n">root</span><span class="p">,</span> <span class="s2">&quot;Nice&quot;</span><span class="p">,</span> <span class="s2">&quot;nice clowns&quot;</span><span class="p">,</span> <span class="n">max_results</span><span class="o">=</span><span class="mi">3</span><span class="p">,</span> <span class="n">random_names</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>Duckduckgo search: nice clowns
+Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice
+</pre>
+</div>
+</div>
+
+<div class="output_area">
+
+
+<div class="output_html rendered_html output_subarea ">
+
+    <div>
+        <style>
+            /* Turns off some styling */
+            progress {
+                /* gets rid of default border in Firefox and Opera. */
+                border: none;
+                /* Needs to be in here for Safari polyfill so background images work as expected. */
+                background-size: auto;
+            }
+            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {
+                background: #F44336;
+            }
+        </style>
+      <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
+      100.00% [3/3 00:02<00:00 Images downloaded]
+    </div>
+    
+</div>
+
+</div>
+
+<div class="output_area">
+
+
+
+<div class="output_text output_subarea output_execute_result">
+<pre>[Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001_2da8aaba.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002_81b6e5b4.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003_956691f0.jpg&#39;)]</pre>
 </div>
 
 </div>
@@ -681,7 +821,8 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
     <span class="s2">&quot;img_size&quot;</span><span class="p">:</span>    <span class="n">ImgSize</span><span class="o">.</span><span class="n">Cached</span><span class="p">,</span> 
     <span class="s2">&quot;img_type&quot;</span><span class="p">:</span>    <span class="n">ImgType</span><span class="o">.</span><span class="n">Photo</span><span class="p">,</span>
     <span class="s2">&quot;img_layout&quot;</span><span class="p">:</span>  <span class="n">ImgLayout</span><span class="o">.</span><span class="n">Square</span><span class="p">,</span>
-    <span class="s2">&quot;img_color&quot;</span><span class="p">:</span>   <span class="n">ImgColor</span><span class="o">.</span><span class="n">All</span>
+    <span class="s2">&quot;img_color&quot;</span><span class="p">:</span>   <span class="n">ImgColor</span><span class="o">.</span><span class="n">All</span><span class="p">,</span>
+    <span class="s2">&quot;random_names&quot;</span><span class="p">:</span> <span class="kc">True</span>
 <span class="p">}</span>
 
 <span class="n">imgs</span> <span class="o">=</span> <span class="p">[]</span>
@@ -702,7 +843,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Duckduckgo search: nice clowns
-Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\Nice
+Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice
 </pre>
 </div>
 </div>
@@ -726,7 +867,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
             }
         </style>
       <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
-      100.00% [3/3 00:00<00:00 Images downloaded]
+      100.00% [3/3 00:02<00:00 Images downloaded]
     </div>
     
 </div>
@@ -737,7 +878,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\N
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Duckduckgo search: scary clowns
-Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\Scary
+Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary
 </pre>
 </div>
 </div>
@@ -761,7 +902,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\S
             }
         </style>
       <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
-      100.00% [3/3 00:00<00:00 Images downloaded]
+      100.00% [3/3 00:02<00:00 Images downloaded]
     </div>
     
 </div>
@@ -772,7 +913,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\S
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Duckduckgo search: mimes
-Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\Mime
+Downloading results into /Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime
 </pre>
 </div>
 </div>
@@ -796,7 +937,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\M
             }
         </style>
       <progress value='3' class='' max='3' style='width:300px; height:20px; vertical-align: middle;'></progress>
-      100.00% [3/3 00:00<00:00 Images downloaded]
+      100.00% [3/3 00:02<00:00 Images downloaded]
     </div>
     
 </div>
@@ -808,15 +949,15 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\M
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>[Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/004.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/005.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Nice/006.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/001.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/002.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Scary/003.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/001.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/002.jpg&#39;),
- Path(&#39;C:/Users/Joe/Documents/GitHub/jmd_imagescraper/images/Mime/003.jpg&#39;)]</pre>
+<pre>[Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/001_c040ccb0.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/002_a7f8e765.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Nice/003_f05a000c.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/001_3a155a2d.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/002_55128fe1.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Scary/003_12a21c43.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/001_9640f045.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/002_8c3198aa.jpg&#39;),
+ Path(&#39;/Users/butch/devt/workspaces/python3/fastai2_2020/jmd_imagescraper/images/Mime/003_5944b53a.jpg&#39;)]</pre>
 </div>
 
 </div>
@@ -852,7 +993,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\M
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="save_urls_to_csv" class="doc_header"><code>save_urls_to_csv</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L211" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>save_urls_to_csv</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>label</code></strong>:<code>str</code>, <strong><code>keywords</code></strong>:<code>str</code>, <strong><code>max_results</code></strong>:<code>int</code>=<em><code>100</code></em>, <strong><code>img_size</code></strong>:<a href="/jmd_imagescraper/core.html#ImgSize"><code>ImgSize</code></a>=<em><code>&lt;ImgSize.Cached: ''&gt;</code></em>, <strong><code>img_type</code></strong>:<a href="/jmd_imagescraper/core.html#ImgType"><code>ImgType</code></a>=<em><code>&lt;ImgType.Photo: 'photo'&gt;</code></em>, <strong><code>img_layout</code></strong>:<a href="/jmd_imagescraper/core.html#ImgLayout"><code>ImgLayout</code></a>=<em><code>&lt;ImgLayout.Square: 'Square'&gt;</code></em>, <strong><code>img_color</code></strong>:<a href="/jmd_imagescraper/core.html#ImgColor"><code>ImgColor</code></a>=<em><code>&lt;ImgColor.All: ''&gt;</code></em>)</p>
+<h4 id="save_urls_to_csv" class="doc_header"><code>save_urls_to_csv</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L216" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>save_urls_to_csv</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>label</code></strong>:<code>str</code>, <strong><code>keywords</code></strong>:<code>str</code>, <strong><code>max_results</code></strong>:<code>int</code>=<em><code>100</code></em>, <strong><code>img_size</code></strong>:<a href="/jmd_imagescraper/core.html#ImgSize"><code>ImgSize</code></a>=<em><code>&lt;ImgSize.Cached: ''&gt;</code></em>, <strong><code>img_type</code></strong>:<a href="/jmd_imagescraper/core.html#ImgType"><code>ImgType</code></a>=<em><code>&lt;ImgType.Photo: 'photo'&gt;</code></em>, <strong><code>img_layout</code></strong>:<a href="/jmd_imagescraper/core.html#ImgLayout"><code>ImgLayout</code></a>=<em><code>&lt;ImgLayout.Square: 'Square'&gt;</code></em>, <strong><code>img_color</code></strong>:<a href="/jmd_imagescraper/core.html#ImgColor"><code>ImgColor</code></a>=<em><code>&lt;ImgColor.All: ''&gt;</code></em>)</p>
 </blockquote>
 <p>Run a search and concat the URLs to a CSV file</p>
 
@@ -952,7 +1093,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\M
     </tr>
     <tr>
       <th>4</th>
-      <td>https://tse1.mm.bing.net/th?id=OIP.9lCTTlLeQV9...</td>
+      <td>https://tse4.mm.bing.net/th?id=OIP.4h5GbgzyJgG...</td>
       <td>Nice</td>
     </tr>
     <tr>
@@ -1011,7 +1152,7 @@ Downloading results into C:\Users\Joe\Documents\GitHub\jmd_imagescraper\images\M
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="download_images_from_csv" class="doc_header"><code>download_images_from_csv</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L231" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>download_images_from_csv</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>csv</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>url_col</code></strong>:<code>str</code>=<em><code>'URL'</code></em>, <strong><code>label_col</code></strong>:<code>str</code>=<em><code>'Label'</code></em>)</p>
+<h4 id="download_images_from_csv" class="doc_header"><code>download_images_from_csv</code><a href="https://github.com/joedockrill/jmd_imagescraper/tree/master/jmd_imagescraper/core.py#L236" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>download_images_from_csv</code>(<strong><code>path</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>csv</code></strong>:<code>Union</code>[<code>str</code>, <code>Path</code>], <strong><code>url_col</code></strong>:<code>str</code>=<em><code>'URL'</code></em>, <strong><code>label_col</code></strong>:<code>str</code>=<em><code>'Label'</code></em>, <strong><code>random_names</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Download the URLs from a CSV file to the given path. Returns a list of Path objects for files downloaded to disc.</p>
 

--- a/jmd_imagescraper/core.py
+++ b/jmd_imagescraper/core.py
@@ -152,7 +152,9 @@ def rmtree(path: Union[str, Path]):
     path.rmdir()
 
 # Cell
-def download_urls(path: Union[str, Path], links: list) -> list:
+import uuid
+
+def download_urls(path: Union[str, Path], links: list, random_names=False) -> list:
   '''Downloads urls to the given path. Returns a list of Path objects for files downloaded to disc.'''
   if(len(links) == 0):
     print("Nothing to download!"); return
@@ -165,7 +167,9 @@ def download_urls(path: Union[str, Path], links: list) -> list:
   pbar.comment = 'Images downloaded'
 
   i = 1
-  mk_fp = lambda x: path/(str(x).zfill(3) + ".jpg")
+  mk_uniq = lambda : '_' + str(uuid.uuid4())[:8] if random_names else ''
+  mk_fp = lambda x: path/(str(x).zfill(3) + mk_uniq() + ".jpg")
+
   is_file = lambda x: mk_fp(x).exists()
   while is_file(i): i += 1 # don't overwrite previous searches
 
@@ -200,12 +204,13 @@ def duckduckgo_search(path: Union[str, Path], label: str, keywords: str, max_res
                            img_size: ImgSize=ImgSize.Cached,
                            img_type: ImgType=ImgType.Photo,
                            img_layout: ImgLayout=ImgLayout.Square,
-                           img_color: ImgColor=ImgColor.All) -> list:
+                           img_color: ImgColor=ImgColor.All,
+                           random_names: bool=False) -> list:
   '''Run a DuckDuckGo search and download the images. Returns a list of Path objects for files downloaded to disc.'''
 
   print("Duckduckgo search:", keywords)
   links = duckduckgo_scrape_urls(keywords, max_results, img_size, img_type, img_layout, img_color)
-  return download_urls(Path(path)/label, links)
+  return download_urls(Path(path)/label, links, random_names=random_names)
 
 # Cell
 def save_urls_to_csv(path: Union[str, Path], label: str, keywords: str, max_results: int=100,
@@ -228,7 +233,7 @@ def save_urls_to_csv(path: Union[str, Path], label: str, keywords: str, max_resu
   df.to_csv(path, index=False)
 
 # Cell
-def download_images_from_csv(path: Union[str, Path], csv: Union[str, Path], url_col: str="URL", label_col: str="Label"):
+def download_images_from_csv(path: Union[str, Path], csv: Union[str, Path], url_col: str="URL", label_col: str="Label", random_names=False):
     '''Download the URLs from a CSV file to the given path. Returns a list of Path objects for files downloaded to disc.'''
     path = Path(path); csv = Path(csv);
 
@@ -239,6 +244,6 @@ def download_images_from_csv(path: Union[str, Path], csv: Union[str, Path], url_
     for label in labels:
         df_label = df.loc[df[label_col] == label]
         urls = df_label[url_col].to_list()
-        imgs.extend(download_urls(path/label, urls))
+        imgs.extend(download_urls(path/label, urls, random_names=random_names))
 
     return imgs


### PR DESCRIPTION
Hi Joe,

This is just a feature enhancement that allows the filenames to have a random string tacked on at the end, allowing the filenames to be unique, even across directories. 

This is to fix a problem with running the `fastai.vision.widgets.ImageClassifierCleaner` which moves the images across the folders if you change their categories. 

This in turn, triggers an error because the filenames are unique within a folder, but not across the different category folders (e.g. reclassifying `003.jpg` in `teddys` folder to a `grizzly` could trigger an error because there might already be a  file named `003.jpg` in the `grizzly` folder)

Adding a random string at the end of the name eg. `001_cc13976d.jpg` instead `001.jpg` makes sure this doesn't happen since each file will be unique even if both files start with `001`.

This additional functionality is turned off by default, so everything works the same unless you explicitly pass the `random_names` parameter to `True`.

Hope you find this a useful feature to merge.

Best regards,
Butch

